### PR TITLE
add keyring to Suggests in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,6 +36,7 @@ Remotes:
     github::PHSKC-APDE/rads, github::PHSKC-APDE/dtsurvey
 Suggests: 
     httr,
+    keyring,
     knitr,
     progress,
     rmarkdown,


### PR DESCRIPTION
 - used in helper.R, but never declared
 - FIXES warning in devtools::check()