### PR TITLE
Fix chi_get_proper_pop use of pop.ages parameter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: apde.chi.tools
 Type: Package
 Title: Simplify Community Health Indicators Analytics Pipeline for Public Health Seattle & King County's Assessment Policy Development and Evaluation Unit
-Version: 2025.0.1
+Version: 2025.0.2
 Authors@R: person(
   "Ronald","Buie", 
   email = "rbuie@kingcounty.gov", 


### PR DESCRIPTION
- previously specified pop.ages were pulled from SQL
  but then a complete template for all ages 0:100 was made.
  Now it ensures that the template of all possible
  demographics is limited to the ages specified by pop.ages