### PR TITLE
Fix when requested years are not in data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: apde.chi.tools
 Type: Package
 Title: Simplify Community Health Indicators Analytics Pipeline for Public Health Seattle & King County's Assessment Policy Development and Evaluation Unit
-Version: 2025.0.3
+Version: 2025.0.4
 Authors@R: person(
   "Ronald","Buie", 
   email = "rbuie@kingcounty.gov", 

--- a/R/chi_calc.R
+++ b/R/chi_calc.R
@@ -95,17 +95,17 @@ chi_calc <- function(ph.data = NULL,
     if (!is.data.table(ph.instructions)) setDT(ph.instructions)
 
     # Validate year range in ph.instructions
-    if (nrow(ph.instructions[end > max(ph.data[['chi_year']], na.rm = T), ]) > 0){
-      warning("\u26A0\ufe0f There are rows in ph.instructions where the end year is > the maximum chi_year in ph.data.\n",
-              "These rows have been dropped from your instructions.", immediate. = TRUE)
-      ph.instructions <- ph.instructions[!(end > max(ph.data[['chi_year']], na.rm = T)),]
-    }
+      if (nrow(ph.instructions[end > max(ph.data[['chi_year']], na.rm = T), ]) > 0){
+        warning("\u26A0\ufe0f There are rows in ph.instructions where the end year is > the maximum chi_year in ph.data.\n",
+                "These rows have been dropped from your instructions.", immediate. = TRUE)
+        ph.instructions <- ph.instructions[!(end > max(ph.data[['chi_year']], na.rm = T)),]
+      }
 
-    if (nrow(ph.instructions[start < min(ph.data[['chi_year']], na.rm = T), ]) > 0){
-      warning("\u26A0\ufe0f There are rows in ph.instructions where the start year is < the minimum chi_year in ph.data.\n",
-              "These rows have been dropped from your instructions.", immediate. = TRUE)
-      ph.instructions <- ph.instructions[!(start < min(ph.data[['chi_year']], na.rm = T)),]
-    }
+      if (nrow(ph.instructions[start < min(ph.data[['chi_year']], na.rm = T), ]) > 0){
+        warning("\u26A0\ufe0f There are rows in ph.instructions where the start year is < the minimum chi_year in ph.data.\n",
+                "These rows have been dropped from your instructions.", immediate. = TRUE)
+        ph.instructions <- ph.instructions[!(start < min(ph.data[['chi_year']], na.rm = T)),]
+      }
 
     # Validate ci parameter
     if (!is.numeric(ci)) stop("\n\U1F6D1 ci must be numeric")

--- a/R/chi_chars_ccs.R
+++ b/R/chi_chars_ccs.R
@@ -11,7 +11,7 @@
 #' @param ph.indicator A character string of length 1. The indicator key to process,
 #' which must exist in the chars.defs data table.
 #' @param ph.data A data.table containing the CHARS data to be processed.
-#' @param myinstructions A data.table containing processing instructions for each indicator.
+#' @param ph.instructions A data.table containing processing instructions for each indicator.
 #'        Default is the output from \code{\link{chi_generate_tro_shell}}.
 #' @param chars.defs A data.table containing definitions for each indicator. It
 #' should have the following columns: `indicator_name`, `indicator_key`, `intent`,
@@ -52,7 +52,7 @@
 #'   chi_chars_ccs(
 #'     ph.indicator = indicator,
 #'     ph.data = chars,
-#'     myinstructions = myinstructions,
+#'     ph.instructions = ph.instructions,
 #'     chars.defs = chars.defs)
 #' }, future.seed = TRUE))
 #'
@@ -66,7 +66,7 @@
 #' \code{\link[rads]{chars_icd_ccs_count}}, in the rads package, which is the
 #' engine used by this function
 #'
-#' \code{\link{chi_generate_tro_shell}}, which creates myinstructions
+#' \code{\link{chi_generate_tro_shell}}, which creates ph.instructions
 #'
 #' @import data.table
 #' @import rads
@@ -74,14 +74,14 @@
 #' @export
 chi_chars_ccs <- function(ph.indicator = NA,
                           ph.data = NULL,
-                          myinstructions = NULL,
+                          ph.instructions = NULL,
                           chars.defs = NULL) {
   # Input validation -----
   if (is.na(ph.indicator)) {
     stop("\n\U1F6D1 ph.indicator must be provided.")
   }
 
-  for (arg_name in c("ph.data", "myinstructions", "chars.defs")) {
+  for (arg_name in c("ph.data", "ph.instructions", "chars.defs")) {
     arg_value <- get(arg_name)
     if (is.null(arg_value)) {
       stop(paste0("\n\U1F6D1 ", arg_name, " must be specified."))
@@ -94,10 +94,10 @@ chi_chars_ccs <- function(ph.indicator = NA,
   }
 
   # Ensure indicator exists
-  instructions <- myinstructions[indicator_key == ph.indicator]
+  instructions <- ph.instructions[indicator_key == ph.indicator]
 
   if (nrow(instructions) == 0) {
-    stop(paste0("\n\U1F6D1 ph.indicator '", ph.indicator, "' not found in myinstructions."))
+    stop(paste0("\n\U1F6D1 ph.indicator '", ph.indicator, "' not found in ph.instructions."))
   }
 
   if (!ph.indicator %in% chars.defs$indicator_key) {
@@ -135,6 +135,18 @@ chi_chars_ccs <- function(ph.indicator = NA,
   if (!all(c("superlevel", "broad", "midlevel", 'detailed') %in% names(indicator_def))) {
     stop("\n\U1F6D1 chars.defs must contain columns 'superlevel', 'broad', 'midlevel', and 'detailed' for CCS indicators.")
   }
+
+  # Validate year range in ph.instructions ----
+    if (nrow(ph.instructions[end > max(ph.data[['chi_year']], na.rm = T), ]) > 0){
+      warning("\u26A0\ufe0f There are rows in ph.instructions where the end year is > the maximum chi_year in ph.data.\n",
+              "These rows have been dropped from your instructions.", immediate. = TRUE)
+      ph.instructions <- ph.instructions[!(end > max(ph.data[['chi_year']], na.rm = T)),]
+    }
+    if (nrow(ph.instructions[start < min(ph.data[['chi_year']], na.rm = T), ]) > 0){
+      warning("\u26A0\ufe0f There are rows in ph.instructions where the start year is < the minimum chi_year in ph.data.\n",
+              "These rows have been dropped from your instructions.", immediate. = TRUE)
+      ph.instructions <- ph.instructions[!(start < min(ph.data[['chi_year']], na.rm = T)),]
+    }
 
   # Import CM reference table ----
   message("Loading ICD-CM reference table (this will happen only once per ph.indicator)")
@@ -258,7 +270,7 @@ chi_chars_ccs <- function(ph.indicator = NA,
         current_row$start,
         sep = "|"
       )
-      message(paste0("myinstructions row ", i, "/", nrow(instructions), ": \n  - ", row_info))
+      message(paste0("ph.instructions row ", i, "/", nrow(instructions), ": \n  - ", row_info))
 
       # Determine if we need ICD-9, ICD-10, or both ----
       current_start <- as.integer(instructions[i, start])
@@ -390,7 +402,7 @@ chi_chars_ccs <- function(ph.indicator = NA,
   setorder(result, tab, year, cat1, cat1_varname, cat1_group, cat2, cat2_varname, cat2_group, chi_age, hospitalizations)
 
   # Identify instructions that caused all data to be filtered out ----
-  # this helps diagnose data quality issues, either in myinstructions or in ph.data
+  # this helps diagnose data quality issues, either in ph.instructions or in ph.data
   if (nrow(result) > 0) {
     # Get combinations actually used in results
     result_combos <- unique(result[, list(indicator_key, tab, cat1, cat1_varname, cat2, cat2_varname,

--- a/R/chi_chars_injury.R
+++ b/R/chi_chars_injury.R
@@ -11,7 +11,7 @@
 #' @param ph.indicator A character string of length 1. The indicator key to process,
 #' which must exist in the chars.defs data table.
 #' @param ph.data A data.table containing the CHARS data to be processed.
-#' @param myinstructions A data.table containing processing instructions for each indicator.
+#' @param ph.instructions A data.table containing processing instructions for each indicator.
 #'        Default is the output from \code{\link{chi_generate_tro_shell}}.
 #' @param chars.defs A data.table containing definitions for each indicator. It
 #' should have the following columns: \code{indicator_name}, \code{indicator_key}, \code{intent},
@@ -55,7 +55,7 @@
 #'   chi_chars_injury(
 #'     ph.indicator = indicator,
 #'     ph.data = chars,
-#'     myinstructions = myinstructions,
+#'     ph.instructions = ph.instructions,
 #'     chars.defs = chars.defs,
 #'     def = 'narrow')
 #' }, future.seed = TRUE))
@@ -70,7 +70,7 @@
 #' \code{\link[rads]{chars_injury_matrix_count}}, in the rads package, which is
 #' the engine used by this function
 #'
-#' \code{\link{chi_generate_tro_shell}}, which creates myinstructions
+#' \code{\link{chi_generate_tro_shell}}, which creates ph.instructions
 #'
 #' @import data.table
 #' @import rads
@@ -78,7 +78,7 @@
 #' @export
 chi_chars_injury <- function(ph.indicator = NA,
                              ph.data = NULL,
-                             myinstructions = NULL,
+                             ph.instructions = NULL,
                              chars.defs = NULL,
                              def = 'narrow') {
   # Input validation -----
@@ -86,7 +86,7 @@ chi_chars_injury <- function(ph.indicator = NA,
     stop("\n\U1F6D1 ph.indicator must be provided.")
   }
 
-  for (arg_name in c("ph.data", "myinstructions", "chars.defs")) {
+  for (arg_name in c("ph.data", "ph.instructions", "chars.defs")) {
     arg_value <- get(arg_name)
     if (is.null(arg_value)) {
       stop(paste0("\n\U1F6D1 ", arg_name, " must be specified."))
@@ -99,10 +99,10 @@ chi_chars_injury <- function(ph.indicator = NA,
   }
 
   # Ensure indicator exists
-  instructions <- myinstructions[indicator_key == ph.indicator]
+  instructions <- ph.instructions[indicator_key == ph.indicator]
 
   if (nrow(instructions) == 0) {
-    stop(paste0("\n\U1F6D1 ph.indicator '", ph.indicator, "' not found in myinstructions."))
+    stop(paste0("\n\U1F6D1 ph.indicator '", ph.indicator, "' not found in ph.instructions."))
   }
 
   if (!ph.indicator %in% chars.defs$indicator_key) {
@@ -149,6 +149,18 @@ chi_chars_injury <- function(ph.indicator = NA,
     stop("\n\U1F6D1 'def' must be either 'narrow' or 'broad'.")
   }
 
+  # Validate year range in ph.instructions ----
+    if (nrow(ph.instructions[end > max(ph.data[['chi_year']], na.rm = T), ]) > 0){
+      warning("\u26A0\ufe0f There are rows in ph.instructions where the end year is > the maximum chi_year in ph.data.\n",
+              "These rows have been dropped from your instructions.", immediate. = TRUE)
+      ph.instructions <- ph.instructions[!(end > max(ph.data[['chi_year']], na.rm = T)),]
+    }
+    if (nrow(ph.instructions[start < min(ph.data[['chi_year']], na.rm = T), ]) > 0){
+      warning("\u26A0\ufe0f There are rows in ph.instructions where the start year is < the minimum chi_year in ph.data.\n",
+              "These rows have been dropped from your instructions.", immediate. = TRUE)
+      ph.instructions <- ph.instructions[!(start < min(ph.data[['chi_year']], na.rm = T)),]
+    }
+
   # Process sequentially ----
   message('\U023F3 Processing calculations... this may take a while')
 
@@ -169,7 +181,7 @@ chi_chars_injury <- function(ph.indicator = NA,
         current_row$start,
         sep = "|"
       )
-      message(paste0("myinstructions row ", i, "/", nrow(instructions), ": \n  - ", row_info))
+      message(paste0("ph.instructions row ", i, "/", nrow(instructions), ": \n  - ", row_info))
 
       # Get current instruction parameters
       current_start <- as.integer(current_row$start)
@@ -311,7 +323,7 @@ chi_chars_injury <- function(ph.indicator = NA,
   setorder(result, tab, year, cat1, cat1_varname, cat1_group, cat2, cat2_varname, cat2_group, chi_age, hospitalizations)
 
   # Identify instructions that caused all data to be filtered out ----
-  # this helps diagnose data quality issues, either in myinstructions or in ph.data
+  # this helps diagnose data quality issues, either in ph.instructions or in ph.data
   if (nrow(result) > 0) {
     # Get combinations actually used in results
     result_combos <- unique(result[, list(indicator_key, tab, cat1, cat1_varname, cat2, cat2_varname,

--- a/R/chi_count_by_age.R
+++ b/R/chi_count_by_age.R
@@ -53,7 +53,19 @@ chi_count_by_age <- function(ph.data = NULL,
     if (!is.data.frame(ph.instructions)) stop("\n\U1F6D1 ph.instructions must be a data.frame or data.table")
     if (!is.null(source_date) & !inherits(source_date, "Date")) stop("\n\U1F6D1 source_date must be of type Date, if it is provided")
 
-    # Convert inputs to data.table if they're not already
+  # Validate year range in ph.instructions ----
+    if (nrow(ph.instructions[end > max(ph.data[['chi_year']], na.rm = T), ]) > 0){
+      warning("\u26A0\ufe0f There are rows in ph.instructions where the end year is > the maximum chi_year in ph.data.\n",
+              "These rows have been dropped from your instructions.", immediate. = TRUE)
+      ph.instructions <- ph.instructions[!(end > max(ph.data[['chi_year']], na.rm = T)),]
+    }
+    if (nrow(ph.instructions[start < min(ph.data[['chi_year']], na.rm = T), ]) > 0){
+      warning("\u26A0\ufe0f There are rows in ph.instructions where the start year is < the minimum chi_year in ph.data.\n",
+              "These rows have been dropped from your instructions.", immediate. = TRUE)
+      ph.instructions <- ph.instructions[!(start < min(ph.data[['chi_year']], na.rm = T)),]
+    }
+
+  # Convert inputs to data.table if they're not already ----
     ph.data <- setDT(copy(ph.data))
     ph.instructions <- setDT(copy(ph.instructions))
 

--- a/R/chi_generate_tro_shell.R
+++ b/R/chi_generate_tro_shell.R
@@ -51,7 +51,7 @@
 #'
 #' \code{\link{chi_calc}}, \code{\link{chi_count_by_age}}, \code{\link{chi_chars_ccs}},
 #' and \code{\link{chi_chars_injury}} for performing
-#' calculations using the output of \code{chi_generate_analysis_set}
+#' calculations using the output of \code{chi_generate_tro_shell}
 #'
 #' @keywords CHI, Tableau, Production
 #'

--- a/man/chi_chars_ccs.Rd
+++ b/man/chi_chars_ccs.Rd
@@ -7,7 +7,7 @@
 chi_chars_ccs(
   ph.indicator = NA,
   ph.data = NULL,
-  myinstructions = NULL,
+  ph.instructions = NULL,
   chars.defs = NULL
 )
 }
@@ -17,7 +17,7 @@ which must exist in the chars.defs data table.}
 
 \item{ph.data}{A data.table containing the CHARS data to be processed.}
 
-\item{myinstructions}{A data.table containing processing instructions for each indicator.
+\item{ph.instructions}{A data.table containing processing instructions for each indicator.
 Default is the output from \code{\link{chi_generate_tro_shell}}.}
 
 \item{chars.defs}{A data.table containing definitions for each indicator. It
@@ -67,7 +67,7 @@ countsCCS <- rbindlist(future_lapply(VectorOfIndicators, function(indicator) {
   chi_chars_ccs(
     ph.indicator = indicator,
     ph.data = chars,
-    myinstructions = myinstructions,
+    ph.instructions = ph.instructions,
     chars.defs = chars.defs)
 }, future.seed = TRUE))
 
@@ -82,5 +82,5 @@ plan(sequential)
 \code{\link[rads]{chars_icd_ccs_count}}, in the rads package, which is the
 engine used by this function
 
-\code{\link{chi_generate_tro_shell}}, which creates myinstructions
+\code{\link{chi_generate_tro_shell}}, which creates ph.instructions
 }

--- a/man/chi_chars_injury.Rd
+++ b/man/chi_chars_injury.Rd
@@ -7,7 +7,7 @@
 chi_chars_injury(
   ph.indicator = NA,
   ph.data = NULL,
-  myinstructions = NULL,
+  ph.instructions = NULL,
   chars.defs = NULL,
   def = "narrow"
 )
@@ -18,7 +18,7 @@ which must exist in the chars.defs data table.}
 
 \item{ph.data}{A data.table containing the CHARS data to be processed.}
 
-\item{myinstructions}{A data.table containing processing instructions for each indicator.
+\item{ph.instructions}{A data.table containing processing instructions for each indicator.
 Default is the output from \code{\link{chi_generate_tro_shell}}.}
 
 \item{chars.defs}{A data.table containing definitions for each indicator. It
@@ -72,7 +72,7 @@ countsINJURY <- rbindlist(future_lapply(VectorOfIndicators, function(indicator) 
   chi_chars_injury(
     ph.indicator = indicator,
     ph.data = chars,
-    myinstructions = myinstructions,
+    ph.instructions = ph.instructions,
     chars.defs = chars.defs,
     def = 'narrow')
 }, future.seed = TRUE))
@@ -88,5 +88,5 @@ plan(sequential)
 \code{\link[rads]{chars_injury_matrix_count}}, in the rads package, which is
 the engine used by this function
 
-\code{\link{chi_generate_tro_shell}}, which creates myinstructions
+\code{\link{chi_generate_tro_shell}}, which creates ph.instructions
 }

--- a/man/chi_generate_tro_shell.Rd
+++ b/man/chi_generate_tro_shell.Rd
@@ -69,7 +69,7 @@ The expected format of \code{ph.analysis_set} is:
 
 \code{\link{chi_calc}}, \code{\link{chi_count_by_age}}, \code{\link{chi_chars_ccs}},
 and \code{\link{chi_chars_injury}} for performing
-calculations using the output of \code{chi_generate_analysis_set}
+calculations using the output of \code{chi_generate_tro_shell}
 }
 \keyword{CHI,}
 \keyword{Production}

--- a/tests/testthat/test-chi_chars_ccs.R
+++ b/tests/testthat/test-chi_chars_ccs.R
@@ -139,23 +139,23 @@ test_that("chi_chars_ccs validates inputs correctly", {
   # Test missing ph.indicator
   expect_error(chi_chars_ccs(ph.indicator = NA,
                              ph.data = mock_chars,
-                             myinstructions = mock_instructions,
+                             ph.instructions = mock_instructions,
                              chars.defs = mock_chars_def),
                "ph.indicator must be provided")
 
   # Test missing ph.data
   expect_error(chi_chars_ccs(ph.indicator = "hos1803000_v1",
                              ph.data = NULL,
-                             myinstructions = mock_instructions,
+                             ph.instructions = mock_instructions,
                              chars.defs = mock_chars_def),
                "ph.data must be specified")
 
   # Test indicator not found in instructions
   expect_error(chi_chars_ccs(ph.indicator = "not_an_indicator",
                              ph.data = mock_chars,
-                             myinstructions = mock_instructions,
+                             ph.instructions = mock_instructions,
                              chars.defs = mock_chars_def),
-               "not found in myinstructions")
+               "not found in ph.instructions")
 
   # Test invalid column in instructions
   bad_instructions <- copy(mock_instructions)
@@ -163,7 +163,7 @@ test_that("chi_chars_ccs validates inputs correctly", {
 
   expect_error(chi_chars_ccs(ph.indicator = "hos1803000_v1",
                              ph.data = mock_chars,
-                             myinstructions = bad_instructions,
+                             ph.instructions = bad_instructions,
                              chars.defs = mock_chars_def),
                "don't exist in ph.data")
 })
@@ -177,7 +177,7 @@ test_that("chi_chars_ccs processes ICD-9 data correctly", {
   result <- chi_chars_ccs(
     ph.indicator = "hos1803000_v1",
     ph.data = mock_chars,
-    myinstructions = icd9_instructions,
+    ph.instructions = icd9_instructions,
     chars.defs = mock_chars_def
   )
 
@@ -210,7 +210,7 @@ test_that("chi_chars_ccs processes ICD-10 data correctly", {
   result <- chi_chars_ccs(
     ph.indicator = "hos1803000_v2",
     ph.data = mock_chars,
-    myinstructions = icd10_instructions,
+    ph.instructions = icd10_instructions,
     chars.defs = mock_chars_def
   )
 
@@ -243,7 +243,7 @@ test_that("chi_chars_ccs processes mixed ICD-9/ICD-10 data correctly", {
   result <- chi_chars_ccs(
     ph.indicator = "hos1803000_v1",
     ph.data = mock_chars,
-    myinstructions = mixed_instructions,
+    ph.instructions = mixed_instructions,
     chars.defs = mock_chars_def
   )
 
@@ -278,7 +278,7 @@ test_that("chi_chars_ccs handles different indicator variables correctly", {
     chi_chars_ccs(
       ph.indicator = indicator,
       ph.data = mock_chars,
-      myinstructions = cat2_instructions,
+      ph.instructions = cat2_instructions,
       chars.defs = mock_chars_def)
   }), fill = TRUE)
 
@@ -314,7 +314,7 @@ test_that("chi_chars_ccs handles WA state filtering correctly", {
   result <- chi_chars_ccs(
     ph.indicator = "hos1803000_v1",
     ph.data = mock_chars,
-    myinstructions = wa_instructions,
+    ph.instructions = wa_instructions,
     chars.defs = mock_chars_def
   )
 
@@ -335,7 +335,7 @@ test_that("chi_chars_ccs handles age filtering correctly", {
   result <- chi_chars_ccs(
     ph.indicator = "hos1803000_v2",
     ph.data = mock_chars,
-    myinstructions = mock_instructions[indicator_key == "hos1803000_v2"],
+    ph.instructions = mock_instructions[indicator_key == "hos1803000_v2"],
     chars.defs = mock_chars_def
   )
 
@@ -357,7 +357,7 @@ test_that("When some instructions filter out all rows, expect it to work but ret
       chi_chars_ccs(
         ph.indicator = indicator,
         ph.data = copy(mock_chars)[, chi_geo_kc := 'KC'],
-        myinstructions = mock_instructions,
+        ph.instructions = mock_instructions,
         chars.defs = mock_chars_def)
     }), fill = TRUE)
   })

--- a/tests/testthat/test-chi_chars_injury.R
+++ b/tests/testthat/test-chi_chars_injury.R
@@ -132,23 +132,23 @@ test_that("chi_chars_injury validates inputs correctly", {
   # Test missing ph.indicator
   expect_error(chi_chars_injury(ph.indicator = NA,
                                 ph.data = mock_chars,
-                                myinstructions = mock_instructions,
+                                ph.instructions = mock_instructions,
                                 chars.defs = mock_chars_def),
                "ph.indicator must be provided")
 
   # Test missing ph.data
   expect_error(chi_chars_injury(ph.indicator = "hos1901000_v1",
                                 ph.data = NULL,
-                                myinstructions = mock_instructions,
+                                ph.instructions = mock_instructions,
                                 chars.defs = mock_chars_def),
                "ph.data must be specified")
 
   # Test indicator not found in instructions
   expect_error(chi_chars_injury(ph.indicator = "not_an_indicator",
                                 ph.data = mock_chars,
-                                myinstructions = mock_instructions,
+                                ph.instructions = mock_instructions,
                                 chars.defs = mock_chars_def),
-               "not found in myinstructions")
+               "not found in ph.instructions")
 
   # Test invalid column in instructions
   bad_instructions <- copy(mock_instructions)
@@ -156,14 +156,14 @@ test_that("chi_chars_injury validates inputs correctly", {
 
   expect_error(chi_chars_injury(ph.indicator = "hos1901000_v1",
                                 ph.data = mock_chars,
-                                myinstructions = bad_instructions,
+                                ph.instructions = bad_instructions,
                                 chars.defs = mock_chars_def),
                "don't exist in ph.data")
 
   # Test invalid def parameter
   expect_error(chi_chars_injury(ph.indicator = "hos1901000_v1",
                                 ph.data = mock_chars,
-                                myinstructions = mock_instructions,
+                                ph.instructions = mock_instructions,
                                 chars.defs = mock_chars_def,
                                 def = "invalid_def"),
                "must be either 'narrow' or 'broad'")
@@ -175,7 +175,7 @@ test_that("chi_chars_injury processes fall injury data correctly", {
   result <- chi_chars_injury(
     ph.indicator = "hos1901000_v1",
     ph.data = mock_chars,
-    myinstructions = mock_instructions[indicator_key == "hos1901000_v1"],
+    ph.instructions = mock_instructions[indicator_key == "hos1901000_v1"],
     chars.defs = mock_chars_def
   )
 
@@ -199,7 +199,7 @@ test_that("chi_chars_injury handles age filtering correctly", {
   result <- chi_chars_injury(
     ph.indicator = "hos1901000_v2",
     ph.data = mock_chars,
-    myinstructions = mock_instructions[indicator_key == "hos1901000_v2"],
+    ph.instructions = mock_instructions[indicator_key == "hos1901000_v2"],
     chars.defs = mock_chars_def
   )
 
@@ -220,7 +220,7 @@ test_that("chi_chars_injury handles different injury types correctly", {
   result <- chi_chars_injury(
     ph.indicator = "hos1902000_v1",
     ph.data = mock_chars,
-    myinstructions = mock_instructions[indicator_key == "hos1902000_v1"],
+    ph.instructions = mock_instructions[indicator_key == "hos1902000_v1"],
     chars.defs = mock_chars_def
   )
 
@@ -241,7 +241,7 @@ test_that("chi_chars_injury handles 'def' parameter correctly", {
   narrow_result <- chi_chars_injury(
     ph.indicator = "hos1901000_v1",
     ph.data = mock_chars,
-    myinstructions = mock_instructions[indicator_key == "hos1901000_v1"][1],
+    ph.instructions = mock_instructions[indicator_key == "hos1901000_v1"][1],
     chars.defs = mock_chars_def,
     def = "narrow"
   )
@@ -250,7 +250,7 @@ test_that("chi_chars_injury handles 'def' parameter correctly", {
   broad_result <- chi_chars_injury(
     ph.indicator = "hos1901000_v1",
     ph.data = mock_chars,
-    myinstructions = mock_instructions[indicator_key == "hos1901000_v1"][1],
+    ph.instructions = mock_instructions[indicator_key == "hos1901000_v1"][1],
     chars.defs = mock_chars_def,
     def = "broad"
   )
@@ -272,7 +272,7 @@ test_that("chi_chars_injury handles WA state filtering correctly", {
   result <- chi_chars_injury(
     ph.indicator = "hos1901000_v1",
     ph.data = mock_chars,
-    myinstructions = wa_instructions,
+    ph.instructions = wa_instructions,
     chars.defs = mock_chars_def
   )
 
@@ -296,7 +296,7 @@ test_that("chi_chars_injury processes multiple instructions correctly", {
   result <- chi_chars_injury(
     ph.indicator = "hos1901000_v1",
     ph.data = mock_chars,
-    myinstructions = multiple_instructions,
+    ph.instructions = multiple_instructions,
     chars.defs = mock_chars_def
   )
 
@@ -320,7 +320,7 @@ test_that("When some instructions filter out all rows, expect it to work but ret
       chi_chars_injury(
         ph.indicator = indicator,
         ph.data = copy(mock_chars)[, chi_geo_kc := 'KC'], # Corrupt the data
-        myinstructions = mock_instructions[indicator_key %in% c("hos1901000_v1", "hos1901000_v2")],
+        ph.instructions = mock_instructions[indicator_key %in% c("hos1901000_v1", "hos1901000_v2")],
         chars.defs = mock_chars_def)
     }), fill = TRUE)
   })
@@ -350,7 +350,7 @@ test_that("chi_chars_injury correctly handles pre-2012 years", {
   result <- chi_chars_injury(
     ph.indicator = "hos1901000_v1",
     ph.data = mock_chars,
-    myinstructions = early_instructions,
+    ph.instructions = early_instructions,
     chars.defs = mock_chars_def
   )
 
@@ -386,7 +386,7 @@ test_that("chi_chars_injury correctly handles poisoning with ICD-10", {
   result <- chi_chars_injury(
     ph.indicator = "hos1902000_v1",
     ph.data = poisoning_test_chars,
-    myinstructions = mock_instructions[indicator_key == "hos1902000_v1"],
+    ph.instructions = mock_instructions[indicator_key == "hos1902000_v1"],
     chars.defs = mock_chars_def
   )
 


### PR DESCRIPTION
When `ph.instructions` requests an analysis for years that are out of range in `ph.data$chi_year`, the illogical rows of `ph.instructions` will be dropped and a warning given. 

This was already the case with `chi_calc(_)`. 

The same code was added to:
`chi_chars_ccs()`
`chi_chars_injury()`
`chi_count_by_age`