### PR TITLE
FIX chi_compare_estimates

### DIFF
--- a/R/chi_compare_estimates.R
+++ b/R/chi_compare_estimates.R
@@ -118,7 +118,7 @@ chi_compare_estimates <- function(OLD = NULL, NEW = NULL, OLD.year = NULL, NEW.y
         qa_type[, qa_type := 'relative']
         qa_type[grepl('mean|proportion', result_type, ignore.case = T) & result >= 0.05, qa_type := 'absolute']
         qa_type[grepl('rate', result_type, ignore.case = T) & result >= 5, qa_type := 'absolute']
-        qa_type <- qa_type[, list(indicator_key, qa_type)]
+        qa_type <- unique(qa_type[, list(indicator_key, qa_type)])
 
       # Merge on qa_type
         comp <- merge(comp, qa_type, by = 'indicator_key', all = T)


### PR DESCRIPTION
ensure that qa_type table is unique before merging. Important because, for some variables, have _kingcounty row for both single year and five year estimates