### PR TITLE
Version 2026.0.3

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,5 @@
 ^LICENSE\.md$
 ^quarto_docs$
 ^data-raw$
+^\.positai$
+^\.claude$

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .RData
 .Ruserdata
 ronNotes.qmd
+.positai

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: apde.chi.tools
 Type: Package
 Title: Simplify Community Health Indicators Analytics Pipeline for Public Health Seattle & King County's Assessment Policy Development and Evaluation Unit
-Version: 2026.0.2
+Version: 2026.0.3
 Authors@R: person(
   "Ronald","Buie", 
   email = "rbuie@kingcounty.gov", 

--- a/R/chi_count_by_age.R
+++ b/R/chi_count_by_age.R
@@ -137,11 +137,23 @@ chi_count_by_age <- function(ph.data = NULL,
                                 by = c("varname", "group"),
                                 all = TRUE)
 
+      byvar_comparison_zipcode <- byvar_comparison[varname == 'zipcode']
+      byvar_comparison <- byvar_comparison[varname != 'zipcode']
+
     # Check for any mismatches between data and reference standards
+      if (nrow(byvar_comparison_zipcode[is.na(reference) | is.na(ph.data)]) > 0) {
+        print(byvar_comparison_zipcode[is.na(reference) | is.na(ph.data)])
+        warning("\u26A0\ufe0f \U0001f6a8 \u26A0\ufe0f\n",
+                "The table above shows the zipcode combinations that do not align between the reference table and your ph.data.",
+                "\nUse your discretion to decide whether you need to make changes.")
+      }
       if (nrow(byvar_comparison[is.na(reference) | is.na(ph.data)]) > 0) {
         print(byvar_comparison[is.na(reference) | is.na(ph.data)])
         stop("\n\U2620 The table above shows the varname/group combinations that do not align between the reference table and your ph.data.")
-      } else {
+      }
+
+      if(nrow(byvar_comparison[is.na(reference) | is.na(ph.data)]) == 0 &
+         nrow(byvar_comparison_zipcode[is.na(reference) | is.na(ph.data)]) == 0) {
         message("\U0001f642 All specified cat1_group and cat2_group values align with the reference standard.")
       }
 

--- a/R/chi_qa_tro.R
+++ b/R/chi_qa_tro.R
@@ -55,7 +55,7 @@ chi_qa_tro <- function(CHIestimates,
                        verbose = TRUE){
   status <- 1
 
-  ## Helper functions
+  ## Helper functions ----
   report_issue <- function(message) {
     status <<- 0
     if(verbose) {
@@ -203,12 +203,19 @@ chi_qa_tro <- function(CHIestimates,
     warning("\U00026A0 Warning: 'rse' is missing in at least one row of the CHI data where the estimate is defined.")
   }
 
-  for(mycol in names(unlist(chi_get_yaml()$metadata))){
-    if(nrow(CHImetadata[is.na(get(mycol))]) > 0){
-      status <- 0
-      warning(paste0("'", mycol, "' is missing in at least one row but is a critical identifier column in CHI metadata."))
+  # check metadata missingness (median income special b/c no last year count)
+  metadata.cols <- names(unlist(chi_get_yaml()$metadata))
+  metadata.cols.medinc <- setdiff(metadata.cols, "latest_year_count")
+  check_missing <- function(dt, cols) {
+    for (mycol in cols) {
+      if (nrow(dt[is.na(get(mycol))]) > 0) {
+        status <- 0
+        warning(paste0("'", mycol, "' is missing in at least one row but is a critical identifier column in CHI metadata."))
+      }
     }
   }
+  check_missing(dt = CHImetadata[indicator_key != "medinc"], cols = metadata.cols)
+  check_missing(dt = CHImetadata[indicator_key == "medinc"], cols = metadata.cols.medinc)
 
   if(status == 0) {
     if(verbose) {
@@ -400,7 +407,7 @@ chi_qa_tro <- function(CHIestimates,
                                              !is.na(result) &
                                              result != rads::round2(result, 1)]
 
-      integers_wrong_rounding <- CHIestimates[result_type == "integer" &
+      integers_wrong_rounding <- CHIestimates[result_type %in% c("count", "dollars", "integer") &
                                                 !is.na(result) &
                                                 result != round(result)]
 
@@ -424,7 +431,7 @@ chi_qa_tro <- function(CHIestimates,
                                              !is.na(lower_bound) &
                                              lower_bound != rads::round2(lower_bound, 1)]
 
-      integers_wrong_rounding <- CHIestimates[result_type == "integer" &
+      integers_wrong_rounding <- CHIestimates[result_type %in% c("count", "dollars", "integer") &
                                                 !is.na(lower_bound) &
                                                 lower_bound != round(lower_bound)]
 
@@ -448,7 +455,7 @@ chi_qa_tro <- function(CHIestimates,
                                              !is.na(upper_bound) &
                                              upper_bound != rads::round2(upper_bound, 1)]
 
-      integers_wrong_rounding <- CHIestimates[result_type == "integer" &
+      integers_wrong_rounding <- CHIestimates[result_type %in% c("count", "dollars", "integer") &
                                                 !is.na(upper_bound) &
                                                 upper_bound != round(upper_bound)]
 
@@ -472,7 +479,7 @@ chi_qa_tro <- function(CHIestimates,
                                              !is.na(se) &
                                              se != rads::round2(se, 2)]
 
-      integers_wrong_rounding <- CHIestimates[result_type == "integer" &
+      integers_wrong_rounding <- CHIestimates[result_type %in% c("count", "dollars", "integer") &
                                                 !is.na(se) &
                                                 se != rads::round2(se, 1)]
 
@@ -680,7 +687,7 @@ chi_qa_tro <- function(CHIestimates,
       message("\u2B50\U2714 Your data has passed all CHI Tableau Ready formatting, style, and logic checks.")
 
     } else {
-      warning("\u26A0\ufe0f At least one check has failed. Please review messages, make corrections, and rerun this check.")
+      warning("\u26A0\ufe0f At least one check has failed. Please review messages above, make corrections if necessary, and rerun this check.")
     }
   }
 

--- a/R/chi_qa_tro.R
+++ b/R/chi_qa_tro.R
@@ -160,7 +160,7 @@ chi_qa_tro <- function(CHIestimates,
   ## Confirm variable class ----
   report_message("Checking that variables are of the proper class")
   report_message("Validating CHI estimates: ")
-  suppressWarnings(rads::tsql_validate_field_types(ph.data = CHIestimates, field_types = unlist(chi_get_yaml()$vars))) # check CHI estimate table
+  rads::tsql_validate_field_types(ph.data = CHIestimates, field_types = unlist(chi_get_yaml()$vars)) # check CHI estimate table
 
   report_message(paste("", "Validating CHI metadata: ", sep = "\n"))
   rads::tsql_validate_field_types(ph.data = CHImetadata, field_types = unlist(chi_get_yaml()$metadata)) # check CHI metadata table

--- a/R/chi_qa_tro.R
+++ b/R/chi_qa_tro.R
@@ -160,7 +160,7 @@ chi_qa_tro <- function(CHIestimates,
   ## Confirm variable class ----
   report_message("Checking that variables are of the proper class")
   report_message("Validating CHI estimates: ")
-  rads::tsql_validate_field_types(ph.data = CHIestimates, field_types = unlist(chi_get_yaml()$vars)) # check CHI estimate table
+  suppressWarnings(rads::tsql_validate_field_types(ph.data = CHIestimates, field_types = unlist(chi_get_yaml()$vars))) # check CHI estimate table
 
   report_message(paste("", "Validating CHI metadata: ", sep = "\n"))
   rads::tsql_validate_field_types(ph.data = CHImetadata, field_types = unlist(chi_get_yaml()$metadata)) # check CHI metadata table


### PR DESCRIPTION
- in `chi_count_by_age()` zipcode mismatches now give warnings rather than errors
- removed unnecessary suppression of warnings from use of `rads::tsql_validate_field_types`
- fixes for ACS data ... need to allow the folllowing:
  -  ACS had 'count' & 'dollars' as valid result_type values
  - ACS 'medinc' does not have latest_year_count value because this doesn't make sense for median income 