### PR TITLE
Version 2026.0.6

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: apde.chi.tools
 Type: Package
 Title: Simplify Community Health Indicators Analytics Pipeline for Public Health Seattle & King County's Assessment Policy Development and Evaluation Unit
-Version: 2026.0.4
+Version: 2026.0.5
 Authors@R: person(
   "Ronald","Buie", 
   email = "rbuie@kingcounty.gov", 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: apde.chi.tools
 Type: Package
 Title: Simplify Community Health Indicators Analytics Pipeline for Public Health Seattle & King County's Assessment Policy Development and Evaluation Unit
-Version: 2026.0.5
+Version: 2026.0.6
 Authors@R: person(
   "Ronald","Buie", 
   email = "rbuie@kingcounty.gov", 

--- a/R/chi_calc.R
+++ b/R/chi_calc.R
@@ -285,6 +285,11 @@ chi_calc <- function(ph.data = NULL,
                                   fancy_time = TRUE)
           }
 
+          # to address chi_year == 'character(0)' when data don't exist
+          # e.g. chi_active_met_1824 is for those 18-24, so no data for those 75+
+          # the following line ensures that chi_year represents all year properly
+          tempest[, chi_year := rads::format_time(valid_years)]
+
           # add on CHI standard columns that are from ph.instructions (in order of standard results output)----
           tempest[, indicator_key := current_row$indicator_key]
           tempest[, tab := current_row$tab]


### PR DESCRIPTION
Fix year output to display full range, not years available (e.g., '2021-2025' NOT '2021, 2023, 20225')
Confirmed with Joie that this is desired output
Passed all tests
0 errors ✔ | 0 warnings ✔ | 0 notes ✔